### PR TITLE
fix: Update link-in-text-block and associated unit tests

### DIFF
--- a/lib/checks/color/link-in-text-block-evaluate.js
+++ b/lib/checks/color/link-in-text-block-evaluate.js
@@ -37,57 +37,58 @@ function linkInTextBlockEvaluate(node) {
 
   this.relatedNodes([parentBlock]);
 
-  // TODO: Check the :visited state of the link
   if (elementIsDistinct(node, parentBlock)) {
     return true;
-  } else {
-    // Check if contrast of foreground is sufficient
-    var nodeColor, parentColor;
-    nodeColor = getForegroundColor(node);
-    parentColor = getForegroundColor(parentBlock);
-
-    if (!nodeColor || !parentColor) {
-      return undefined;
-    }
-
-    var contrast = getContrast(nodeColor, parentColor);
-    if (contrast === 1) {
-      return true;
-    } else if (contrast >= 3.0) {
-      incompleteData.set('fgColor', 'bgContrast');
-      this.data({
-        messageKey: incompleteData.get('fgColor')
-      });
-      incompleteData.clear();
-      // User needs to check whether there is a hover and a focus style
-      return undefined;
-    }
-
-    // Check if contrast of background is sufficient
-    nodeColor = getBackgroundColor(node);
-    parentColor = getBackgroundColor(parentBlock);
-
-    if (
-      !nodeColor ||
-      !parentColor ||
-      getContrast(nodeColor, parentColor) >= 3.0
-    ) {
-      let reason;
-      if (!nodeColor || !parentColor) {
-        reason = incompleteData.get('bgColor');
-      } else {
-        reason = 'bgContrast';
-      }
-      incompleteData.set('fgColor', reason);
-      this.data({
-        messageKey: incompleteData.get('fgColor')
-      });
-      incompleteData.clear();
-      return undefined;
-    }
   }
 
-  // TODO: We should check the focus / hover style too
+  // Capture colors, exiting early in case of error
+  var nodeColor = getForegroundColor(node);
+  var parentColor = getForegroundColor(parentBlock);
+
+  if (!nodeColor || !parentColor) {
+    return undefined;
+  }
+
+  var nodeBackgroundColor = getBackgroundColor(node);
+  var parentBackgroundColor = getBackgroundColor(parentBlock);
+
+  if (!nodeBackgroundColor || !parentBackgroundColor) {
+    var reason = incompleteData.get('bgColor') ?? 'bgContrast';
+    this.data({
+      messageKey: reason
+    });
+    incompleteData.clear();
+    return undefined;
+  }
+
+  // Compute ratios and return pass or fail, as appropriate
+  var textContrast = getContrast(nodeColor, parentColor);
+  var backgroundContrast = getContrast(
+    nodeBackgroundColor,
+    parentBackgroundColor
+  );
+
+  if (textContrast >= 3.0 || backgroundContrast >= 3.0) {
+    return true;
+  }
+
+  // Message reflects the highest contrast ratio since it's the smallest fix
+  if (textContrast >= backgroundContrast) {
+    this.data({
+      messageKey: 'fgContrast',
+      contrastRatio: textContrast,
+      nodeColor,
+      parentColor
+    });
+  } else {
+    this.data({
+      messageKey: 'bgContrast',
+      contrastRatio: backgroundContrast,
+      nodeBackgroundColor,
+      parentBackgroundColor
+    });
+  }
+
   return false;
 }
 

--- a/lib/checks/color/link-in-text-block.json
+++ b/lib/checks/color/link-in-text-block.json
@@ -8,7 +8,7 @@
       "fail": {
         "default": "Links need to be distinguished from surrounding text in some way other than by color",
         "fgContrast": "Element has insufficient color contrast of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}. Expected contrast ratio of 3.0.",
-        "bgContrast": "Element has insufficient background color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}. Expected contrast ratio of 3.0."
+        "bgContrast": "Element's background has insufficient color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}) with background of text block. Expected contrast ratio of 3.0."
       },
       "incomplete": {
         "default": "Element's foreground contrast ratio could not be determined",

--- a/lib/checks/color/link-in-text-block.json
+++ b/lib/checks/color/link-in-text-block.json
@@ -5,10 +5,14 @@
     "impact": "serious",
     "messages": {
       "pass": "Links can be distinguished from surrounding text in some way other than by color",
-      "fail": "Links need to be distinguished from surrounding text in some way other than by color",
+      "fail": {
+        "default": "Links need to be distinguished from surrounding text in some way other than by color",
+        "fgContrast": "Element has insufficient color contrast of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}. Expected contrast ratio of 3.0.",
+        "bgContrast": "Element has insufficient background color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}. Expected contrast ratio of 3.0."
+      },
       "incomplete": {
-        "default": "Unable to determine contrast ratio",
-        "bgContrast": "Element's contrast ratio could not be determined. Check for a distinct hover/focus style",
+        "default": "Element's foreground contrast ratio could not be determined",
+        "bgContrast": "Element's background contrast ratio could not be determined",
         "bgImage": "Element's contrast ratio could not be determined due to a background image",
         "bgGradient": "Element's contrast ratio could not be determined due to a background gradient",
         "imgNode": "Element's contrast ratio could not be determined because element contains an image node",

--- a/lib/checks/color/link-in-text-block.json
+++ b/lib/checks/color/link-in-text-block.json
@@ -7,7 +7,7 @@
       "pass": "Links can be distinguished from surrounding text in some way other than by color",
       "fail": {
         "default": "Links need to be distinguished from surrounding text in some way other than by color",
-        "fgContrast": "Element has insufficient color contrast of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}. Expected contrast ratio of 3.0.",
+        "fgContrast": "Element has insufficient color contrast with parent text block of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}). Expected contrast ratio of 3.0.",
         "bgContrast": "Element's background has insufficient color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}) with background of text block. Expected contrast ratio of 3.0."
       },
       "incomplete": {

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -607,8 +607,8 @@
       "pass": "Links can be distinguished from surrounding text in some way other than by color",
       "fail": {
         "default": "Links need to be distinguished from surrounding text in some way other than by color",
-        "fgContrast": "Element has insufficient color contrast of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}. Expected contrast ratio of 3.0.",
-        "bgContrast": "Element has insufficient background color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}. Expected contrast ratio of 3.0."
+        "fgContrast": "Element has insufficient color contrast with parent text block of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}). Expected contrast ratio of 3.0.",
+        "bgContrast": "Element's background has insufficient color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}) with background of text block. Expected contrast ratio of 3.0."
       },
       "incomplete": {
         "default": "Element's foreground contrast ratio could not be determined",

--- a/locales/_template.json
+++ b/locales/_template.json
@@ -605,10 +605,14 @@
     },
     "link-in-text-block": {
       "pass": "Links can be distinguished from surrounding text in some way other than by color",
-      "fail": "Links need to be distinguished from surrounding text in some way other than by color",
+      "fail": {
+        "default": "Links need to be distinguished from surrounding text in some way other than by color",
+        "fgContrast": "Element has insufficient color contrast of ${data.contrastRatio} (link color: ${data.nodeColor}, parent color: ${data.parentColor}. Expected contrast ratio of 3.0.",
+        "bgContrast": "Element has insufficient background color contrast of ${data.contrastRatio} (link background color: ${data.nodeBackgroundColor}, parent background color: ${data.parentBackgroundColor}. Expected contrast ratio of 3.0."
+      },
       "incomplete": {
-        "default": "Unable to determine contrast ratio",
-        "bgContrast": "Element's contrast ratio could not be determined. Check for a distinct hover/focus style",
+        "default": "Element's foreground contrast ratio could not be determined",
+        "bgContrast": "Element's background contrast ratio could not be determined",
         "bgImage": "Element's contrast ratio could not be determined due to a background image",
         "bgGradient": "Element's contrast ratio could not be determined due to a background gradient",
         "imgNode": "Element's contrast ratio could not be determined because element contains an image node",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test": "npm run test:tsc && run-s \"test:unit:* -- {@}\" --",
     "test:tsc": "tsc",
     "test:unit": "karma start test/karma.conf.js",
-    "test:debug": "npm run test:unit:checks -- --no-single-run --browsers=Chrome",
+    "test:debug": "npm run test:unit -- --no-single-run --browsers=Chrome",
     "test:unit:core": "npm run test:unit -- testDirs=core",
     "test:unit:commons": "npm run test:unit -- testDirs=commons",
     "test:unit:rule-matches": "npm run test:unit -- testDirs=rule-matches",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "test": "npm run test:tsc && run-s \"test:unit:* -- {@}\" --",
     "test:tsc": "tsc",
     "test:unit": "karma start test/karma.conf.js",
-    "test:debug": "npm run test:unit -- --no-single-run --browsers=Chrome",
+    "test:debug": "npm run test:unit:checks -- --no-single-run --browsers=Chrome",
     "test:unit:core": "npm run test:unit -- testDirs=core",
     "test:unit:commons": "npm run test:unit -- testDirs=commons",
     "test:unit:rule-matches": "npm run test:unit -- testDirs=rule-matches",

--- a/test/checks/color/link-in-text-block.js
+++ b/test/checks/color/link-in-text-block.js
@@ -1,4 +1,4 @@
-describe('link-in-text-block', function() {
+describe('link-in-text-block', function () {
   'use strict';
 
   var fixture = document.getElementById('fixture');
@@ -7,7 +7,7 @@ describe('link-in-text-block', function() {
 
   var checkContext = axe.testUtils.MockCheckContext();
 
-  before(function() {
+  before(function () {
     styleElm = document.createElement('style');
     document.head.appendChild(styleElm);
   });
@@ -17,17 +17,17 @@ describe('link-in-text-block', function() {
     textDecoration: 'none'
   };
 
-  beforeEach(function() {
+  beforeEach(function () {
     createStyleString('p', defaultStyle);
   });
 
-  afterEach(function() {
+  afterEach(function () {
     fixture.innerHTML = '';
     styleElm.innerHTML = '';
     checkContext.reset();
   });
 
-  after(function() {
+  after(function () {
     styleElm.parentNode.removeChild(styleElm);
   });
 
@@ -47,12 +47,12 @@ describe('link-in-text-block', function() {
     }
 
     var cssLines = Object.keys(styleObj)
-      .map(function(prop) {
+      .map(function (prop) {
         // Make camelCase prop dash separated
         var cssPropName = prop
           .trim()
           .split(/(?=[A-Z])/g)
-          .reduce(function(prop, propPiece) {
+          .reduce(function (prop, propPiece) {
             if (!prop) {
               return propPiece;
             } else {
@@ -89,30 +89,14 @@ describe('link-in-text-block', function() {
     return document.getElementById(linkId);
   }
 
-  it('returns true if links have the exact same color', function() {
-    var linkElm = getLinkElm(
-      {
-        color: 'black'
-      },
-      {
-        color: '#000'
-      }
-    );
-    assert.isTrue(
-      axe.testUtils
-        .getCheckEvaluate('link-in-text-block')
-        .call(checkContext, linkElm)
-    );
-  });
-
-  describe('link default state', function() {
-    beforeEach(function() {
+  describe('link default state', function () {
+    beforeEach(function () {
       createStyleString('a', {
-        color: '#100' // insufficeint contrast
+        color: '#100' // insufficient contrast
       });
     });
 
-    it('passes the selected node and closest ancestral block element', function() {
+    it('passes the selected node and closest ancestral block element', function () {
       fixture.innerHTML =
         '<div> <span style="display:block; color: #100" id="parent">' +
         '	<p style="display:inline"><a href="" id="link">' +
@@ -123,39 +107,46 @@ describe('link-in-text-block', function() {
       axe.testUtils.flatTreeSetup(fixture);
       var linkElm = document.getElementById('link');
 
-      assert.isTrue(
+      assert.isFalse(
         axe.testUtils
           .getCheckEvaluate('link-in-text-block')
           .call(checkContext, linkElm)
       );
+      assert.equal(checkContext._data.messageKey, 'fgContrast');
     });
 
     (shadowSupport.v1 ? it : xit)(
       'works with the block outside the shadow tree',
-      function() {
+      function () {
         var parentElm = document.createElement('div');
-        parentElm.setAttribute('style', 'color:#100;');
+        parentElm.setAttribute(
+          'style',
+          'color:#100; background-color:#FFFFFF;'
+        );
         var shadow = parentElm.attachShadow({ mode: 'open' });
-        shadow.innerHTML = '<a href="" style="color:#100;">Link</a>';
+        shadow.innerHTML =
+          '<a href="" style="color:#000; background-color:#FFFFFF; text-decoration:none;">Link</a>';
         var linkElm = shadow.querySelector('a');
         fixture.appendChild(parentElm);
 
         axe.testUtils.flatTreeSetup(fixture);
 
-        assert.isTrue(
+        assert.isFalse(
           axe.testUtils
             .getCheckEvaluate('link-in-text-block')
             .call(checkContext, linkElm)
         );
+        assert.equal(checkContext._data.messageKey, 'fgContrast');
       }
     );
 
     (shadowSupport.v1 ? it : xit)(
       'works with the link inside the shadow tree slot',
-      function() {
+      function () {
         var div = document.createElement('div');
-        div.setAttribute('style', 'color:#100;');
-        div.innerHTML = '<a href="" style="color:#100;">Link</a>';
+        div.setAttribute('style', 'color:#100; background-color:#FFFFFF;');
+        div.innerHTML =
+          '<a href="" style="color:#000;background-color:#FFFFFF;">Link</a>';
         var shadow = div.attachShadow({ mode: 'open' });
         shadow.innerHTML = '<p><slot></slot></p>';
         fixture.appendChild(div);
@@ -163,92 +154,24 @@ describe('link-in-text-block', function() {
         axe.testUtils.flatTreeSetup(fixture);
         var linkElm = div.querySelector('a');
 
-        assert.isTrue(
+        assert.isFalse(
           axe.testUtils
             .getCheckEvaluate('link-in-text-block')
             .call(checkContext, linkElm)
         );
+        assert.equal(checkContext._data.messageKey, 'fgContrast');
       }
     );
   });
 
-  describe('links distinguished through color', function() {
-    beforeEach(function() {
+  describe('links distinguished through color', function () {
+    beforeEach(function () {
       createStyleString('a:active, a:focus', {
         textDecoration: 'underline'
       });
     });
 
-    it('returns undefined if text contrast >= 3:0', function() {
-      var linkElm = getLinkElm(
-        {
-          color: 'cyan'
-        },
-        {
-          color: 'black'
-        }
-      );
-      assert.isUndefined(
-        axe.testUtils
-          .getCheckEvaluate('link-in-text-block')
-          .call(checkContext, linkElm)
-      );
-    });
-
-    it('returns false if text contrast < 3:0', function() {
-      var linkElm = getLinkElm(
-        {
-          color: '#000010'
-        },
-        {
-          color: '#000000'
-        }
-      );
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('link-in-text-block')
-          .call(checkContext, linkElm)
-      );
-    });
-
-    it('returns undefined if background contrast >= 3:0', function() {
-      var linkElm = getLinkElm(
-        {
-          color: '#000010',
-          backgroundColor: 'purple'
-        },
-        {
-          color: '#000000',
-          backgroundColor: 'white'
-        }
-      );
-      assert.isUndefined(
-        axe.testUtils
-          .getCheckEvaluate('link-in-text-block')
-          .call(checkContext, linkElm)
-      );
-      assert.equal(checkContext._data.messageKey, 'bgContrast');
-    });
-
-    it('returns false if background contrast < 3:0', function() {
-      var linkElm = getLinkElm(
-        {
-          color: '#000010',
-          backgroundColor: '#FFE'
-        },
-        {
-          color: '#000000',
-          backgroundColor: '#FFF'
-        }
-      );
-      assert.isFalse(
-        axe.testUtils
-          .getCheckEvaluate('link-in-text-block')
-          .call(checkContext, linkElm)
-      );
-    });
-
-    it('returns undefined if the background contrast can not be determined', function() {
+    it('returns undefined if the background contrast can not be determined', function () {
       var linkElm = getLinkElm(
         {},
         {
@@ -266,26 +189,100 @@ describe('link-in-text-block', function() {
           .call(checkContext, linkElm)
       );
       assert.equal(checkContext._data.messageKey, 'bgImage');
+      assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
     });
-  });
 
-  it('returns relatedNodes with undefined', function() {
-    var linkElm = getLinkElm(
-      {},
-      {
-        color: '#000010',
-        backgroundImage:
-          'url(data:image/gif;base64,R0lGODlhEAAQAMQAAORHHOVSKudfOulrSOp3WOyDZu6QdvCchPGolfO0o/XBs/fNwfjZ0frl3/zy7////wAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH5BAkAABAALAAAAAAQABAAAAVVICSOZGlCQAosJ6mu7fiyZeKqNKToQGDsM8hBADgUXoGAiqhSvp5QAnQKGIgUhwFUYLCVDFCrKUE1lBavAViFIDlTImbKC5Gm2hB0SlBCBMQiB0UjIQA7)'
-      },
-      {
-        color: '#000000'
-      }
-    );
-    assert.isUndefined(
-      axe.testUtils
-        .getCheckEvaluate('link-in-text-block')
-        .call(checkContext, linkElm)
-    );
-    assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
+    it('returns false with fgContrast key if nodes have same foreground color and same background color', function () {
+      var linkElm = getLinkElm(
+        {
+          color: 'black'
+        },
+        {
+          color: '#000'
+        }
+      );
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('link-in-text-block')
+          .call(checkContext, linkElm)
+      );
+      assert.equal(checkContext._data.messageKey, 'fgContrast');
+      assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
+    });
+
+    it('returns false with fgContrast key if nodes have insufficient foreground contrast and same background color', function () {
+      var linkElm = getLinkElm(
+        {
+          color: 'black'
+        },
+        {
+          color: '#100'
+        }
+      );
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('link-in-text-block')
+          .call(checkContext, linkElm)
+      );
+      assert.equal(checkContext._data.messageKey, 'fgContrast');
+    });
+
+    it('returns false with bgContrast key if nodes have same foreground color and insufficient background contrast', function () {
+      var linkElm = getLinkElm(
+        {
+          color: 'black',
+          backgroundColor: 'white'
+        },
+        {
+          color: '#000',
+          backgroundColor: '#F0F0F0'
+        }
+      );
+      assert.isFalse(
+        axe.testUtils
+          .getCheckEvaluate('link-in-text-block')
+          .call(checkContext, linkElm)
+      );
+      assert.equal(checkContext._data.messageKey, 'bgContrast');
+      assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
+    });
+
+    it('returns true if nodes have sufficient foreground contrast and insufficient background contrast', function () {
+      var linkElm = getLinkElm(
+        {
+          color: 'black',
+          backgroundColor: 'white'
+        },
+        {
+          color: '#606060',
+          backgroundColor: '#F0F0F0'
+        }
+      );
+      assert.isTrue(
+        axe.testUtils
+          .getCheckEvaluate('link-in-text-block')
+          .call(checkContext, linkElm)
+      );
+      assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
+    });
+
+    it('returns true if nodes have insufficient foreground contrast and sufficient background contrast', function () {
+      var linkElm = getLinkElm(
+        {
+          color: 'black',
+          backgroundColor: 'white'
+        },
+        {
+          color: '#100',
+          backgroundColor: '#808080'
+        }
+      );
+      assert.isTrue(
+        axe.testUtils
+          .getCheckEvaluate('link-in-text-block')
+          .call(checkContext, linkElm)
+      );
+      assert.equal(checkContext._relatedNodes[0], linkElm.parentNode);
+    });
   });
 });


### PR DESCRIPTION
A preview PR intended to update `link-in-text-block` rule as described in axe-core [#2817](https://github.com/dequelabs/axe-core/issues/2817). The new rule works as follows:

- return `false` if the link is not actually a link (unchanged from before)
- return `true` is the link and the containing text block have visually distinct styling independent of color (unchanged from before)
- return `undefined` if we fail to obtain foreground and background colors of both the link and its containing text block. This is a slight change from before because an old code path returned `true` without checking the background colors if the foreground contrast ratio was 1.0. Possible values of `messageKey`:
  - `default` if we fail to obtain the foreground color of either the link or the containing text block
  - `bgContrast` if we fail to obtain background colors of either the link or the containing text block and no value for `bgColor` was set via `incompleteData`
  - `bgImage`, `bgGradient`, `imgNode`, or `bgOverlap` if a value for `bgColor` was set via `incompleteData` when trying to obtain a background color
- Compute contrast ratios for both foreground and background colors
- return `true` if _either_ the foreground contrast ratio or the background contrast ratio is at least 3.0
- return `false` with an appropriate value for `messageKey`:
  - `fgContrast` if the foreground ratio >= the background ratio
  - `bgContrast` if the background ratio > the foreground ratio

Strings in the json file have been updated to include more information about the colors that were used to compute the ratios. Unit tests have been updated (and slightly regrouped) to pin the updated behavior.

This covers the rule changes for [#2817](https://github.com/dequelabs/axe-core/issues/2817), but it leaves the rule categorized as experimental. Changing the rule category will need a separate change.
